### PR TITLE
Remove `dev-center` base url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,7 +3,7 @@ module.exports = {
     title,
     tagline: "by developers, for developers",
     url: "https://geocortex.github.io/",
-    baseUrl: process.env.BASE_URL || "/dev-center/",
+    baseUrl: "/",
     favicon: "img/favicon.png",
     organizationName: "geocortex", // Usually your GitHub org/user name.
     projectName: "dev-center", // Usually your repo name.


### PR DESCRIPTION
Removes the `/dev-center/` base url to support moving to our new domain.