### PR TITLE
Add file names to code samples for custom server activities

### DIFF
--- a/docs/workflow/snippets/logarithm-activity.mdx
+++ b/docs/workflow/snippets/logarithm-activity.mdx
@@ -1,4 +1,4 @@
-```csharp
+```csharp title="App1/App1/CustomActivity.cs"
 using Geocortex.Workflow.Runtime;
 using System;
 using System.Collections.Generic;

--- a/docs/workflow/usecases-server-implement-custom-activity.mdx
+++ b/docs/workflow/usecases-server-implement-custom-activity.mdx
@@ -26,7 +26,7 @@ Follow the instructions to [set up a new Geocortex Workflow Server extension pro
 1. Create a new file `CustomActivity` in the project.
 2. Add a new skeleton workflow activity that implements `IActivityHandler`.
 
-```csharp
+```csharp title="App1/App1/CustomActivity.cs"
 using Geocortex.Workflow.Runtime;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -54,7 +54,7 @@ Use a unique prefix on the `Action` property to avoid it conflicting with someon
 1. Create a new file, `Properties\AssemblyInfo.cs`
 1. Add the custom Geocortex Workflow attribute to `AssemblyInfo.cs`:
 
-```csharp
+```csharp title="App1/App1/Properties/AssemblyInfo.cs"
 [assembly: Geocortex.Workflow.Runtime.WorkflowActivities]`
 ```
 


### PR DESCRIPTION
The code examples on the "Implement a Custom Activity" page for Geocortex Server do not use file names, even though they are complete, copyable, examples. (See the Contribution Guidelines for file names).