### PR TITLE
Add link to Geocortex Web product page

### DIFF
--- a/docs/web/overview.mdx
+++ b/docs/web/overview.mdx
@@ -7,7 +7,7 @@ import DesignerCallout from "./snippets/designer-callout.mdx";
 import UseCaseCard from "../../src/components/UseCaseCard";
 import UseCaseContainer from "../../src/components/UseCaseContainer";
 
-Geocortex Web is a next-generation framework for creating sleek and effective GIS applications for a wide variety of browsers. Apps allow users to view and interact with web-based maps and associated data. Geocortex Web can seamlessly display both 2D and 3D map data. Integration with [Geocortex Workflow](../workflow/overview.mdx) ensures that you can build apps for many business processes. Geocortex Web is part of the [Geocortex suite of products](https://www.geocortex.com/products/).
+[Geocortex Web](https://www.geocortex.com/products/gxw/) is a next-generation framework for creating sleek and effective GIS applications for a wide variety of browsers. Apps allow users to view and interact with web-based maps and associated data. Geocortex Web can seamlessly display both 2D and 3D map data. Integration with [Geocortex Workflow](../workflow/overview.mdx) ensures that you can build apps for many business processes. Geocortex Web is part of the [Geocortex suite of products](https://www.geocortex.com/products/).
 
 Geocortex Web apps are created, configured and deployed with [Geocortex Web Designer](https://apps.geocortex.com/webviewer/designer/). Web Designer is an intuitive web application that displays a live preview of Geocortex Web apps as they are being configured.
 


### PR DESCRIPTION
First occurance of Geocortex Web now links to https://www.geocortex.com/products/gxw/