### PR TITLE
Fix commands and operations registration

### DIFF
--- a/docs/web/configuration-app-config.mdx
+++ b/docs/web/configuration-app-config.mdx
@@ -85,7 +85,7 @@ If you do not provide a `config` attribute for a component, Geocortex Web will a
 
 ## Targeting Components by ID
 
-Every component can also have an `id` attribute. The `id` attribute uniquely identifies a component within a layout and allows app items to target the component. The id can be used by [commands](configuration-commands-operations.mdx) like `ui.activate` to target components, or by commands like `run.workflow` to target a host container component to display workflow UI within.
+Every component can also have an `id` attribute. The `id` attribute uniquely identifies a component within a layout and allows app items to target the component. The ID can be used by [commands](configuration-commands-operations.mdx) like `ui.activate` to target components, or by commands like `run.workflow` to target a host container component to display workflow UI within.
 
 :::note
 This example uses [commands and operations](configuration-commands-operations.mdx) to power its behavior.

--- a/docs/web/sdk-components-commands-operations.mdx
+++ b/docs/web/sdk-components-commands-operations.mdx
@@ -57,11 +57,19 @@ export default function CustomComponent(props) {
 
 ## Implementing Commands and Operations
 
-Components can also register an implementation for any command or operation. This allows the creation of commands which can affect the UI. When registering a command implementation for a component, you have to register the implementation in the [component's model](sdk-component-reference.mdx#models). The following component model registers an implementation for a custom command that takes a `string` argument.
+Components can also register an implementation for any command or operation. This allows the creation of commands which can affect the UI. When registering a command implementation for a component, you have to register the implementation in the [component's model](sdk-component-reference.mdx#models). The command must also be registered in the library entry point. The following component model registers an implementation for a custom command that takes a custom argument type.
 
 :::note
 It's best practice to expose the arguments and return values for commands and operations as public interfaces, as this allows consumers of the command or operation to have the appropriate typing.
 :::
+
+<Tabs
+  defaultValue="model"
+  values={[
+    { label: "Component Model", value: "model" },
+    { label: "Registration", value: "registration" },
+  ]}>
+<TabItem value="model">
 
 ```tsx
 export interface CustomCommandArg {
@@ -95,6 +103,20 @@ export default class CustomModel extends ComponentModelBase {
     }
 }
 ```
+
+</TabItem>
+<TabItem value="registration">
+
+```ts
+export default function (registry: LibraryRegistry) {
+    ...
+
+    registry.registerCommand("custom.my-command")
+}
+```
+
+</TabItem>
+</Tabs>
 
 ## Running Custom Commands
 

--- a/docs/web/sdk-components-commands-operations.mdx
+++ b/docs/web/sdk-components-commands-operations.mdx
@@ -125,18 +125,22 @@ You can run the custom commands or operations you define from another component,
 ```ts
 @serializable
 export default class ExampleComponentModel extends ComponentModelBase {
-    async runCustomCommandsAndOperations(){
-         // highlight-start
-        await command<CustomCommandArg>("custom.my-command").execute({ someProp: "some arg" });
+    async runCustomCommandsAndOperations() {
+        // highlight-start
+        await command<CustomCommandArg>("custom.my-command").execute({
+            someProp: "some arg",
+        });
         // highlight-end
 
         // highlight-start
-        const result = await operation<InputArgType, OutputArgType>("custom.my-operation").execute({
+        const result = await operation<InputArgType, OutputArgType>(
+            "custom.my-operation"
+        ).execute({
             some: "arg",
         });
         // highlight-end
-        ...
+        // ...
     }
-    ...
+    // ...
 }
 ```

--- a/docs/web/sdk-services-commands-operations.mdx
+++ b/docs/web/sdk-services-commands-operations.mdx
@@ -50,17 +50,77 @@ export default class ExampleService extends ServiceBase {
 
 ## Implementing Commands and Operations
 
-Services can also register an implementation for any command or operation. The following service registers an implementation for a custom command that takes a `string` argument.
+Services can also register an implementation for any command or operation. Services can either register a command or operation by a static reference to a function, or by dynamically registering the implementation at runtime.
+
+### Static Registration
+
+Services can register a command or operation using the id of the service, and the name of a method on the service that will be called. The following service registers an implementation for a custom operation that returns a custom command type.
 
 :::note
 It's best practice to expose the arguments and return values for commands and operations as public interfaces, as this allows consumers of the command or operation to have the appropriate typing.
 :::
 
-```tsx
+<Tabs
+  defaultValue="service"
+  values={[
+    { label: "Service", value: "service" },
+    { label: "Registration", value: "registration" }
+  ]}>
+<TabItem value="registration">
+
+```ts
+export default function (registry: LibraryRegistry) {
+    ...
+
+    registry.registerService({
+        id: "custom-service",
+        getServiceType: () => CustomService
+    });
+
+    registry.registerOperation("custom.my-operation", {
+        serviceId: "custom-service",
+        // highlight-next-line
+        executeMethodName: "_executeMyOperation",
+    });
+}
+```
+
+</TabItem>
+<TabItem value="service">
+
+```ts
 export interface CustomCommandArg {
     someProp: string;
 }
 
+export default class ExampleService extends ServiceBase {
+    // highlight-next-line
+    protected _executeMyOperation(): Promise<CustomCommandArg> {
+        // ... do work here
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Dynamic Registration
+
+Implementations for commands and operations can also be registered at runtime. This allows for dynamic implementations of commands and operations. The following service registers an implementation for a custom command that takes a `string`.
+
+:::important  
+It's important to cleanup command registration handles to prevent memory issues.
+:::
+
+<Tabs
+  defaultValue="service"
+  values={[
+    { label: "Service", value: "service" },
+    { label: "Registration", value: "registration" }
+  ]}>
+<TabItem value="service">
+
+```tsx
 export default class ExampleService extends ServiceBase {
     private _handles: IHandle[] = [];
 
@@ -69,10 +129,10 @@ export default class ExampleService extends ServiceBase {
 
         this._handles.push(
             this.messages
-                .command<CustomCommandArg>("custom.my-command")
-                .register((arg: CustomCommandArg) => {
+                .command<string>("custom.my-command")
+                .register((arg: string) => {
                     console.log(
-                        `Executing 'custom.my-command' with argument '${arg.someProp}'`
+                        `Executing 'custom.my-command' with argument '${arg}'`
                     );
                     return;
                 })
@@ -85,6 +145,19 @@ export default class ExampleService extends ServiceBase {
     }
 }
 ```
+
+</TabItem>
+<TabItem value="registration">
+
+```ts
+export default function (registry: LibraryRegistry) {
+    ...
+    registry.registerCommand("custom.my-command");
+}
+```
+
+</TabItem>
+</Tabs>
 
 ## Running Custom Commands
 

--- a/docs/web/sdk-services-commands-operations.mdx
+++ b/docs/web/sdk-services-commands-operations.mdx
@@ -50,11 +50,7 @@ export default class ExampleService extends ServiceBase {
 
 ## Implementing Commands and Operations
 
-Services can also register an implementation for any command or operation. Services can either register a command or operation by a static reference to a function, or by dynamically registering the implementation at runtime.
-
-### Static Registration
-
-Services can register a command or operation using the id of the service, and the name of a method on the service that will be called. The following service registers an implementation for a custom operation that returns a custom command type.
+Services can also register an implementation for a command or operation. A command or operation is registered using the ID of the service and the name of the method on the service that will be called. The following service registers an implementation for an operation that returns a custom type.
 
 :::note
 It's best practice to expose the arguments and return values for commands and operations as public interfaces, as this allows consumers of the command or operation to have the appropriate typing.
@@ -98,61 +94,6 @@ export default class ExampleService extends ServiceBase {
     protected _executeMyOperation(): Promise<CustomCommandArg> {
         // ... do work here
     }
-}
-```
-
-</TabItem>
-</Tabs>
-
-### Dynamic Registration
-
-Implementations for commands and operations can also be registered at runtime. This allows for dynamic implementations of commands and operations. The following service registers an implementation for a custom command that takes a `string`.
-
-:::important  
-It's important to cleanup command registration handles to prevent memory issues.
-:::
-
-<Tabs
-  defaultValue="service"
-  values={[
-    { label: "Service", value: "service" },
-    { label: "Registration", value: "registration" }
-  ]}>
-<TabItem value="service">
-
-```tsx
-export default class ExampleService extends ServiceBase {
-    private _handles: IHandle[] = [];
-
-    protected async _onInitialize(): Promise<void> {
-        await super._onInitialize();
-
-        this._handles.push(
-            this.messages
-                .command<string>("custom.my-command")
-                .register((arg: string) => {
-                    console.log(
-                        `Executing 'custom.my-command' with argument '${arg}'`
-                    );
-                    return;
-                })
-        );
-    }
-
-    destroy(): void {
-        // Clean up event handlers.
-        this._handles.forEach((h) => h.remove());
-    }
-}
-```
-
-</TabItem>
-<TabItem value="registration">
-
-```ts
-export default function (registry: LibraryRegistry) {
-    ...
-    registry.registerCommand("custom.my-command");
 }
 ```
 


### PR DESCRIPTION
The documentation for implemeting commands and operations in services and components was missing the `index.ts` registration piece.