### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,6 @@ coverage
 # Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
-# Bower dependency directory (https://bower.io/)
-bower_components
-
 # node-waf configuration
 .lock-wscript
 

--- a/cspell.json
+++ b/cspell.json
@@ -11,7 +11,7 @@
         "bootstrapper",
         "broadview",
         "callout",
-        "classnames",
+        "clsx",
         "configitemtype",
         "configurability",
         "cors",

--- a/docs/web/sdk-reference-third-party-libraries.mdx
+++ b/docs/web/sdk-reference-third-party-libraries.mdx
@@ -7,22 +7,22 @@ description: Geocortex Web - Reference third party libraries with the Geocortex 
 
 You can install packages directly from [npm](https://www.npmjs.com/) the same way you would in other JavaScript projects, and import them in your code using the [ES6 import syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import):
 
-For example, to install and use the [classnames](https://github.com/JedWatson/classnames), first install the package:
+For example, to install and use [clsx](https://github.com/lukeed/clsx), first install the package:
 
 ```sh
-npm install classnames
+npm install clsx
 ```
 
 and then import it in your code:
 
 ```tsx
 // highlight-next-line
-import classNames from "classnames";
+import clsx from "clsx";
 
 export default function ExampleComponent(props) {
     return (
         <div
-            className={classNames("ExampleComponent", {
+            className={clsx("ExampleComponent", {
                 "ExampleComponent-active": props.active,
             })}
         >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,9 +1072,9 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@docusaurus/core": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-+P/2T6aeBcwJbg4a7Y/6CrGL4GKDjTESKwhf41naGsA4v98o5P23eIiKngBvfTPVwHXu3MDShE6UU+lnFqBXyQ==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-7VW7IQKTxTIeCXxzraLdTqRtYSmEG2ZJDt07z26NjK+17XyNQc0IoJs7M3xhjzaeP0s/CpYe5Yl+pgp6TIXqoA==",
       "requires": {
         "@babel/core": "^7.9.0",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
@@ -1083,7 +1083,7 @@
         "@babel/preset-react": "^7.9.4",
         "@babel/preset-typescript": "^7.9.0",
         "@babel/runtime": "^7.9.2",
-        "@docusaurus/utils": "^2.0.0-alpha.56",
+        "@docusaurus/utils": "^2.0.0-alpha.58",
         "@endiliey/static-site-generator-webpack-plugin": "^4.0.0",
         "@svgr/webpack": "^5.4.0",
         "babel-loader": "^8.1.0",
@@ -1091,7 +1091,6 @@
         "cache-loader": "^4.1.0",
         "chalk": "^3.0.0",
         "chokidar": "^3.3.0",
-        "classnames": "^2.2.6",
         "commander": "^4.0.1",
         "copy-webpack-plugin": "^5.0.5",
         "core-js": "^2.6.5",
@@ -1119,7 +1118,7 @@
         "react-dev-utils": "^10.2.1",
         "react-helmet": "^6.0.0-beta",
         "react-loadable": "^5.5.0",
-        "react-loadable-ssr-addon": "^0.2.0",
+        "react-loadable-ssr-addon": "^0.2.3",
         "react-router": "^5.1.2",
         "react-router-config": "^5.1.1",
         "react-router-dom": "^5.1.2",
@@ -1136,9 +1135,9 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-GXlQMB6z5Zl6f1zAjE3PaUOAPGPYF0vYQR8Qz8RETyVmDCHumoAAT4/NSDrPYMLrdcp4BrMUn4PoNK4MK5462w==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-g/uqzaoaRkwuPmjOB7/p58vNFLev9yE3FdkVfD19mSHyaMaKAzWGUiJxkaxPFtxCs4mwFWk7tJKSLY+B8MjS2Q==",
       "requires": {
         "@babel/parser": "^7.9.4",
         "@babel/traverse": "^7.9.0",
@@ -1176,12 +1175,12 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-oqCRv3PQe7sXI5+IqOpezluUs5oG39ctO8M2ZHNqf5vG+5tafr82rpKTpwp2uL3AahVlp7xkWRKF6LGNLCHQZA==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-2Pn15pwPdnmKLAvNd4bk2XclnGtGYCpfAECypm9tBql6W6MShy0qOHH3JGLY8dQIMySsCkuC3jCl26EwXNgARw==",
       "requires": {
-        "@docusaurus/mdx-loader": "^2.0.0-alpha.56",
-        "@docusaurus/utils": "^2.0.0-alpha.56",
+        "@docusaurus/mdx-loader": "^2.0.0-alpha.58",
+        "@docusaurus/utils": "^2.0.0-alpha.58",
         "feed": "^4.1.0",
         "fs-extra": "^8.1.0",
         "globby": "^10.0.1",
@@ -1212,12 +1211,12 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-vRM/Zi80PV7+U/rQ+5e4XknqqELgCAoNr+bc8+aA6je6CgHLjxwySVJvEChe/36QCYhax9eSnpWgoQKkfSXHdg==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-+PHqften1daJXBxUZTN5pMIRP7NwGU7reO4QX0iy7Qp1Wqs63KPY/nSeM7dtxKCYtU+yWkLogvFlicARVqRU9A==",
       "requires": {
-        "@docusaurus/mdx-loader": "^2.0.0-alpha.56",
-        "@docusaurus/utils": "^2.0.0-alpha.56",
+        "@docusaurus/mdx-loader": "^2.0.0-alpha.58",
+        "@docusaurus/utils": "^2.0.0-alpha.58",
         "execa": "^3.4.0",
         "fs-extra": "^8.1.0",
         "globby": "^10.0.1",
@@ -1295,58 +1294,68 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-8mHqiWyk90ExFprE7S7O2N7oW6jOLOtf64JVCGzDdMVKkKJJZY8VHWb7EP2D/pkMiByunrD1yJj933ZIjFD+0g==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-4LJn2CB83ZCkM4+0qNQWdm4gA2Og3QzmUfSqYOifTmsVsHuLSAqa5zRkkSSsZ244r+ya4e7nmS7nMd7kfK+v4w==",
       "requires": {
-        "@docusaurus/types": "^2.0.0-alpha.56",
-        "@docusaurus/utils": "^2.0.0-alpha.56",
+        "@docusaurus/types": "^2.0.0-alpha.58",
+        "@docusaurus/utils": "^2.0.0-alpha.58",
         "globby": "^10.0.1"
       }
     },
+    "@docusaurus/plugin-debug": {
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-w7sEUzuavp5N4TxgJus1TLFwRkypvg9+mRYZN+mgV05WF3ft+aDTToWeYNZq/8FoC1IEwkezOpPpaWtG4UWM7Q==",
+      "requires": {
+        "@docusaurus/types": "^2.0.0-alpha.58",
+        "@docusaurus/utils": "^2.0.0-alpha.58"
+      }
+    },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-nL1hfPqUWJSAoMBqlLSF/ZlQ/HlOnZc4VQSqR5FkZV2UNhPI0kQKiIeBjzQFtODxfWfDBs2PQLMiA2Qx3Hme6A=="
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-R4I8j+XJkOl7fz8+lRnQKr8YP4zrG6dWBNZ66JquUwL6jmaavq1VRVavm7/s5Wr/vYLcpEWjynHViwDdVLegoQ=="
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-5BAMGvplzortF+wKpabGKqATa+WtNCHQeqRZwQtGLNZFgYEcJR55DAlb3+YHEAspAE39VGk16GQAWkni6j123g=="
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-t+B6K2/EvRofygDK5edeQAg2l069aU7H3sViG/3USpJSaY9bWNWRKjZk6BEOypC+mCW6g5HQgewQZ/bTkV+aDA=="
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-A9gJuilowS/6bMBR7vobQUg1um5WL6eVohfHmhFsYPVko+7Al4Sya01A926R0OLviwQ9ItGA6wdCvYbmIAV6BQ==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-OS3XZG1S/USyZxSZ4e2pputW3sOl/hxvK+EAs51eOi/fYyVgO4BmFpcsoP17a5d1Cnxf8gumOkS6bLRDaG8KyQ==",
       "requires": {
-        "@docusaurus/types": "^2.0.0-alpha.56",
+        "@docusaurus/types": "^2.0.0-alpha.58",
         "sitemap": "^3.2.2"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-/N+R0JiKiMNELDDTQk4/PFIM5jKR0wJFd5tj/P07YWmpquzMS9GI8SeA83sKTqol/6BaG3pQKbNl0pCBf1T63A==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-XGXC5NcAkRUKpm4aho6moThPtLarGSouWW1xfYMQlT4dY6RG/FFt8n5viMXzGwOfA/H9B/s0sZpqHDw8U4FUCg==",
       "requires": {
-        "@docusaurus/plugin-content-blog": "^2.0.0-alpha.56",
-        "@docusaurus/plugin-content-docs": "^2.0.0-alpha.56",
-        "@docusaurus/plugin-content-pages": "^2.0.0-alpha.56",
-        "@docusaurus/plugin-google-analytics": "^2.0.0-alpha.56",
-        "@docusaurus/plugin-google-gtag": "^2.0.0-alpha.56",
-        "@docusaurus/plugin-sitemap": "^2.0.0-alpha.56",
-        "@docusaurus/theme-classic": "^2.0.0-alpha.56",
-        "@docusaurus/theme-search-algolia": "^2.0.0-alpha.56"
+        "@docusaurus/plugin-content-blog": "^2.0.0-alpha.58",
+        "@docusaurus/plugin-content-docs": "^2.0.0-alpha.58",
+        "@docusaurus/plugin-content-pages": "^2.0.0-alpha.58",
+        "@docusaurus/plugin-debug": "^2.0.0-alpha.58",
+        "@docusaurus/plugin-google-analytics": "^2.0.0-alpha.58",
+        "@docusaurus/plugin-google-gtag": "^2.0.0-alpha.58",
+        "@docusaurus/plugin-sitemap": "^2.0.0-alpha.58",
+        "@docusaurus/theme-classic": "^2.0.0-alpha.58",
+        "@docusaurus/theme-search-algolia": "^2.0.0-alpha.58"
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-+gdlqrbmizLukbveGK3UA+uedScSAtKcJCEjfrR2J/PmmsDdtPB3E5mY1j0AUZWGDhERF9NVeAsZgOHBzTTkhw==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-GvpzpsL3jTxm/3sPna7wOJaAauCha+uLZ33x/XOMKrfN02E2BLkaRphRyCliw1vvLXB3rJPlHyvBdKCTOVXaNw==",
       "requires": {
         "@mdx-js/mdx": "^1.5.8",
         "@mdx-js/react": "^1.5.8",
-        "classnames": "^2.2.6",
-        "clipboard": "^2.0.6",
+        "clsx": "^1.1.1",
+        "copy-text-to-clipboard": "^2.2.0",
         "infima": "0.2.0-alpha.12",
         "parse-numeric-range": "^0.0.2",
         "prism-react-renderer": "^1.1.0",
@@ -1357,21 +1366,21 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-0LFjM7eE8mu+4pNH42Y+pTuy6fHEgUSFrWjaS4eeJ97ervyXHhIYPYXv6z4+S0ZDu/hFk3ON5LZ+gUCsWKCnvw==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-Iug5mET733Yx46E04BfJjz4+AvxzalRo8G4ZmOjePTMiKQpE1ee39Ypbwj77c8XxEadOcZC4mJtfxB3L1RqlBA==",
       "requires": {
         "algoliasearch": "^3.24.5",
         "algoliasearch-helper": "^3.1.1",
-        "classnames": "^2.2.6",
+        "clsx": "^1.1.1",
         "docsearch.js": "^2.6.3",
         "eta": "^1.1.1"
       }
     },
     "@docusaurus/types": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-N3IFESY+u9m4O9nDKatgO0hB8s5di5e8fZ6VmPTBtrOjG3ruruAGt3ho96UVDeLK2++DakKXnl9VCZ+CJ85wXg==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-OSkxoLwWJMhEHa4s6SXVCjfGwYm21yF6ZggoUo6kz+qqslTgF/JcPCVF9Y1Hf6bJJxUisi+ZHrHKEC6k4pphPA==",
       "requires": {
         "@types/webpack": "^4.41.0",
         "commander": "^4.0.1",
@@ -1379,9 +1388,9 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-alpha.56.tgz",
-      "integrity": "sha512-CMII7BYMQ5Dg9sHcejbxbyHTCG4CHQc/uFasL8FNXkHn7crw5Pz2re+IutSklE2SEI5lOZtMl5Lt8HKDvHzG1g==",
+      "version": "2.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-alpha.58.tgz",
+      "integrity": "sha512-hBhdQCyVT15mH7RE5yuDBuhwbUnM4beKq2JLvRuZS4FoNu7T2S4OGusUAtTnNZEruoUv2QTkt+GrsRDKYi2fCA==",
       "requires": {
         "escape-string-regexp": "^2.0.0",
         "fs-extra": "^8.1.0",
@@ -1444,23 +1453,23 @@
       }
     },
     "@mdx-js/mdx": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.5.tgz",
-      "integrity": "sha512-DC13eeEM0Dv9OD+UVhyB69BlV29d2eoAmfiR/XdgNl4R7YmRNEPGRD3QvGUdRUDxYdJBHauMz5ZIV507cNXXaA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.6.tgz",
+      "integrity": "sha512-Q1j/RtjNbRZRC/ciaOqQLplsJ9lb0jJhDSvkusmzCsCX+NZH7YTUvccWf7l6zKW1CAiofJfqZdZtXkeJUDZiMw==",
       "requires": {
         "@babel/core": "7.9.6",
         "@babel/plugin-syntax-jsx": "7.8.3",
         "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@mdx-js/util": "^1.6.5",
-        "babel-plugin-apply-mdx-type-prop": "^1.6.5",
-        "babel-plugin-extract-import-names": "^1.6.5",
+        "@mdx-js/util": "^1.6.6",
+        "babel-plugin-apply-mdx-type-prop": "^1.6.6",
+        "babel-plugin-extract-import-names": "^1.6.6",
         "camelcase-css": "2.0.1",
         "detab": "2.0.3",
         "hast-util-raw": "5.0.2",
         "lodash.uniq": "4.5.0",
         "mdast-util-to-hast": "9.1.0",
         "remark-footnotes": "1.0.0",
-        "remark-mdx": "^1.6.5",
+        "remark-mdx": "^1.6.6",
         "remark-parse": "8.0.2",
         "remark-squeeze-paragraphs": "4.0.0",
         "style-to-object": "0.3.0",
@@ -1508,14 +1517,14 @@
       }
     },
     "@mdx-js/react": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.5.tgz",
-      "integrity": "sha512-y1Yu9baw3KokFrs7g5RxHpJNSU4e1zk/5bAJX94yVATglG5HyAL0lYMySU8YzebXNE+fJJMCx9CuiQHy2ezoew=="
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.6.tgz",
+      "integrity": "sha512-zOOdNreHUNSFQ0dg3wYYg9sOGg2csf7Sk8JGBigeBq+4Xk4LO0QdycGAmgKNfeme+SyBV5LBIPjt1NNsScyWEQ=="
     },
     "@mdx-js/util": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.5.tgz",
-      "integrity": "sha512-ljr9hGQYW3kZY1NmQbmSe4yXvgq3KDRt0FMBOB5OaDWqi4X2WzEsp6SZ02KmVrieNW1cjWlj13pgvcf0towZPw=="
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.6.tgz",
+      "integrity": "sha512-PKTHVgMHnK5p+kcMWWNnZuoR7O19VmHiOujmVcyN50hya7qIdDb5vvsYC+dwLxApEXiABhLozq0dlIwFeS3yjg=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -2490,12 +2499,12 @@
       }
     },
     "babel-plugin-apply-mdx-type-prop": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.5.tgz",
-      "integrity": "sha512-Bs2hv/bYFTJyhBqvsWOsceFyPXAhVM1gvwF8fIm6GeXYTQV+sY+qRR5TClamgr3OEsD8ZApmw+kxJSHgJggVyw==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.6.tgz",
+      "integrity": "sha512-rUzVvkQa8/9M63OZT6qQQ1bS8P0ozhXp9e5uJ3RwRJF5Me7s4nZK5SYhyNHYc0BkAflWnCOGMP3oPQUfuyB8tg==",
       "requires": {
         "@babel/helper-plugin-utils": "7.8.3",
-        "@mdx-js/util": "^1.6.5"
+        "@mdx-js/util": "^1.6.6"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
@@ -2514,9 +2523,9 @@
       }
     },
     "babel-plugin-extract-import-names": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.5.tgz",
-      "integrity": "sha512-rrNoCZ1DHMdy3vuihvkuO2AjE2DVFrI78e61W7eVsgpNTbG0KO1UESQwXMTlS3v1PMnlEJjdvoteRAkatEkWFQ==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.6.tgz",
+      "integrity": "sha512-UtMuiQJnhVPAGE2+pDe7Nc9NVEmDdqGTN74BtRALgH+7oag88RpxFLOSiA+u5mFkFg741wW9Ut5KiyJpksEj/g==",
       "requires": {
         "@babel/helper-plugin-utils": "7.8.3"
       },
@@ -3362,6 +3371,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
       "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "optional": true,
       "requires": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
@@ -3442,6 +3452,11 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "coa": {
       "version": "2.0.2",
@@ -3722,6 +3737,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "copy-text-to-clipboard": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz",
+      "integrity": "sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ=="
     },
     "copy-webpack-plugin": {
       "version": "5.1.1",
@@ -4768,7 +4788,8 @@
     "delegate": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -5033,14 +5054,14 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.3.475",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.475.tgz",
-      "integrity": "sha512-vcTeLpPm4+ccoYFXnepvkFt0KujdyrBU19KNEO40Pnkhta6mUi2K0Dn7NmpRcNz7BvysnSqeuIYScP003HWuYg=="
+      "version": "1.3.477",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.477.tgz",
+      "integrity": "sha512-81p6DZ/XmHDD7O0ITJMa7ESo9bSCfE+v3Fny3MIYR0y77xmhoriu2ShNOLXcPS4eowF6dkxw6d2QqxTkS3DjBg=="
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -6197,6 +6218,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
       "requires": {
         "delegate": "^3.1.2"
       }
@@ -11662,15 +11684,15 @@
       "integrity": "sha512-X9Ncj4cj3/CIvLI2Z9IobHtVi8FVdUrdJkCNaL9kdX8ohfsi18DXHsCVd/A7ssARBdccdDb5ODnt62WuEWaM/g=="
     },
     "remark-mdx": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.5.tgz",
-      "integrity": "sha512-zItwP3xcVQAEPJTHseFh+KZEyJ31+pbVJMOMzognqTuZ2zfzIR4Xrg0BAx6eo+paV4fHne/5vi2ugWtCeOaBRA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.6.tgz",
+      "integrity": "sha512-BkR7SjP+3OvrCsWGlYy1tWEsZ8aQ86x+i7XWbW79g73Ws/cCaeVsEn0ZxAzzoTRH+PJWVU7Mbe64GdejEyKr2g==",
       "requires": {
         "@babel/core": "7.9.6",
         "@babel/helper-plugin-utils": "7.8.3",
         "@babel/plugin-proposal-object-rest-spread": "7.9.6",
         "@babel/plugin-syntax-jsx": "7.8.3",
-        "@mdx-js/util": "^1.6.5",
+        "@mdx-js/util": "^1.6.6",
         "is-alphabetical": "1.0.4",
         "remark-parse": "8.0.2",
         "unified": "9.0.0"
@@ -12079,7 +12101,8 @@
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -13246,7 +13269,8 @@
     "tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true
     },
     "tiny-invariant": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1696,9 +1696,9 @@
       "integrity": "sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA=="
     },
     "@types/json-schema": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
     },
     "@types/mdast": {
       "version": "3.0.3",
@@ -1719,9 +1719,9 @@
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
     "@types/node": {
-      "version": "14.0.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.12.tgz",
-      "integrity": "sha512-/sjzehvjkkpvLpYtN6/2dv5kg41otMGuHQUt9T2aiAuIfleCQRQHXXzF1eAw/qkZTj5Kcf4JSTf7EIizHocy6Q=="
+      "version": "14.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1744,9 +1744,9 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/react": {
-      "version": "16.9.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
-      "integrity": "sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==",
+      "version": "16.9.38",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.38.tgz",
+      "integrity": "sha512-pHAeZbjjNRa/hxyNuLrvbxhhnKyKNiLC6I5fRF2Zr/t/S6zS41MiyzH4+c+1I9vVfvuRt1VS2Lodjr4ZWnxrdA==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -1758,9 +1758,9 @@
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA=="
     },
     "@types/tapable": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.5.tgz",
-      "integrity": "sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
+      "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA=="
     },
     "@types/uglify-js": {
       "version": "3.9.2",
@@ -2014,9 +2014,9 @@
       "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
     },
     "acorn-walk": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
-      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
     },
     "address": {
       "version": "1.1.2",
@@ -2627,6 +2627,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3130,9 +3139,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001079",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001079.tgz",
-      "integrity": "sha512-2KaYheg0iOY+CMmDuAB3DHehrXhhb4OZU4KBVGDr/YKyYAcpudaiUQ9PJ9rxrPlKEoJ3ATasQ5AN48MqpwS43Q=="
+      "version": "1.0.30001084",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001084.tgz",
+      "integrity": "sha512-ftdc5oGmhEbLUuMZ/Qp3mOpzfZLCxPYKcvGv6v2dJJ+8EdqcvZRbAGOiLmkM/PV1QGta/uwBs8/nCl6sokDW6w=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -3651,9 +3660,9 @@
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
     "consola": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.12.2.tgz",
-      "integrity": "sha512-c9mzemrAk57s3UIjepn8KKkuEH5fauMdot5kFSJUnqHcnApVS9Db8Rbv5AZ1Iz6lXzaGe9z1crQXhJtGX4h/Og=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.13.0.tgz",
+      "integrity": "sha512-Jw+8qpL0yrpfqH9m90fWoDRQyn8TYU6Aegpl4UofoP81VYvQLoOWMpFw2vQ3U/cyLRRzTc/CyNC6YYVzZFU8Eg=="
     },
     "console-browserify": {
       "version": "1.2.0",
@@ -4349,22 +4358,22 @@
       }
     },
     "css-loader": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.5.3.tgz",
-      "integrity": "sha512-UEr9NH5Lmi7+dguAm+/JSPovNjYbm2k3TK58EiwQHzOHH5Jfq1Y+XoP2bQO6TMn7PptMd0opxxedAWcaSTRKHw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
+      "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
       "requires": {
         "camelcase": "^5.3.1",
         "cssesc": "^3.0.0",
         "icss-utils": "^4.1.1",
         "loader-utils": "^1.2.3",
         "normalize-path": "^3.0.0",
-        "postcss": "^7.0.27",
+        "postcss": "^7.0.32",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.2",
         "postcss-modules-scope": "^2.2.0",
         "postcss-modules-values": "^3.0.0",
-        "postcss-value-parser": "^4.0.3",
-        "schema-utils": "^2.6.6",
+        "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^2.7.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -5024,9 +5033,9 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.3.465",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.465.tgz",
-      "integrity": "sha512-K/lUeT3NLAsJ5SHRDhK3/zd0tw7OUllYD8w+fTOXm6ljCPsp2qq+vMzxpLo8u1M27ZjZAjRbsA6rirvne2nAMQ=="
+      "version": "1.3.475",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.475.tgz",
+      "integrity": "sha512-vcTeLpPm4+ccoYFXnepvkFt0KujdyrBU19KNEO40Pnkhta6mUi2K0Dn7NmpRcNz7BvysnSqeuIYScP003HWuYg=="
     },
     "elliptic": {
       "version": "6.5.2",
@@ -5078,9 +5087,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-      "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.2.0.tgz",
+      "integrity": "sha512-S7eiFb/erugyd1rLb6mQ3Vuq+EXHv5cpCkNqqIkYkBgN2QdFnyCZzFBleqwGEx4lgNGYij81BWnCrFNK7vxvjQ==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
@@ -5151,21 +5160,21 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -5513,9 +5522,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -5574,6 +5583,12 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.0.1",
@@ -5674,22 +5689,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "requires": {
-        "debug": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+      "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -7009,9 +7011,9 @@
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
     },
     "immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
     },
     "immer": {
       "version": "1.10.0",
@@ -7798,9 +7800,9 @@
           }
         },
         "chalk": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -8659,6 +8661,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11256,9 +11264,9 @@
       }
     },
     "react-loadable-ssr-addon": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon/-/react-loadable-ssr-addon-0.2.2.tgz",
-      "integrity": "sha512-Xk6lqe4Vr14SLSbB93U5JzewdKS77dqslQkhttJ5zpkXbacDF/yjjFT44/EXSqwIWN4gEEerJ5b4IU8v/1NyXw=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon/-/react-loadable-ssr-addon-0.2.3.tgz",
+      "integrity": "sha512-vPCqsmiafAMDcS9MLgXw3m4yMI40v1UeI8FTYJJkjf85LugKNnHf6D9yoDTzYwp8wEGF5viekwOD03ZPxSwnQQ=="
     },
     "react-router": {
       "version": "5.2.0",
@@ -11774,9 +11782,9 @@
       }
     },
     "remark-validate-links": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/remark-validate-links/-/remark-validate-links-10.0.0.tgz",
-      "integrity": "sha512-BLVKPCoF8BLZCgJyDNw8rEL9++ohx+lpc6eZl7GNmHxJi3SR5tA7JYNcEVmcDj7M6Kl04wmc6BaeJ1FYNQDaIQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-validate-links/-/remark-validate-links-10.0.2.tgz",
+      "integrity": "sha512-rcg/FFgowCbR7fC5aNhpJu8ltXuSGZZunwIwReXtdZ704XHsHR3Xsy4N8uso43ih5cY9maIydfn1FNLHW0016w==",
       "requires": {
         "github-slugger": "^1.0.0",
         "hosted-git-info": "^3.0.0",
@@ -12819,26 +12827,6 @@
         "es-abstract": "^1.17.5"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
-      }
-    },
     "string.prototype.trimstart": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
@@ -13039,9 +13027,9 @@
       "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw=="
     },
     "terser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.7.0.tgz",
-      "integrity": "sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -13550,9 +13538,9 @@
       }
     },
     "unified-args": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/unified-args/-/unified-args-8.0.0.tgz",
-      "integrity": "sha512-224jfXOL0Xu0e52fJTfxmAaNTuW1zopPmnXh/5GDAxx4Z6NbcZpjgQPBmo1xoLAhGih0rWVG2+a2kodzrEHfHw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/unified-args/-/unified-args-8.1.0.tgz",
+      "integrity": "sha512-t1HPS1cQPsVvt/6EtyWIbQGurza5684WGRigNghZRvzIdHm3LPgMdXPyGx0npORKzdiy5+urkF0rF5SXM8lBuQ==",
       "requires": {
         "camelcase": "^5.0.0",
         "chalk": "^3.0.0",
@@ -14204,7 +14192,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -14571,9 +14563,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+          "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -14784,7 +14776,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "deploy": "docusaurus deploy"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-alpha.56",
-    "@docusaurus/preset-classic": "2.0.0-alpha.56",
+    "@docusaurus/core": "2.0.0-alpha.58",
+    "@docusaurus/preset-classic": "2.0.0-alpha.58",
     "@types/react": "^16.9.38",
-    "classnames": "^2.2.6",
+    "clsx": "^1.1.1",
     "cspell": "^4.0.63",
     "husky": "3.1.0",
     "linkinator": "^2.1.1",
@@ -38,10 +38,10 @@
       "not op_mini all"
     ],
     "development": [
-      "last 2 chrome version",
-      "last 2 edge version",
-      "last 2 firefox version",
-      "last 2 safari version"
+      "last 1 chrome version",
+      "last 1 edge version",
+      "last 1 firefox version",
+      "last 1 safari version"
     ]
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.56",
     "@docusaurus/preset-classic": "2.0.0-alpha.56",
-    "@types/react": "^16.9.35",
+    "@types/react": "^16.9.38",
     "classnames": "^2.2.6",
     "cspell": "^4.0.63",
     "husky": "3.1.0",
@@ -29,7 +29,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "remark-cli": "^8.0.0",
-    "remark-validate-links": "^10.0.0"
+    "remark-validate-links": "^10.0.2"
   },
   "browserslist": {
     "production": [

--- a/src/components/ExtensibilitySpectrum/index.jsx
+++ b/src/components/ExtensibilitySpectrum/index.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styles from "./index.module.css";
-import classNames from "classnames";
+import clsx from "clsx";
 
 function AppConfigSvg() {
     return (
@@ -63,10 +63,7 @@ function CustomCodeSvg() {
             </g>
             <g>
                 <path
-                    className={classNames(
-                        styles.svgFillBlue,
-                        styles.svgStrokeBlue
-                    )}
+                    className={clsx(styles.svgFillBlue, styles.svgStrokeBlue)}
                     d="M125.6 176l-29.2-20.8v-5.1l29.2-22.6v9.2l-21.3 15.7v.2l21.3 14.2v9.2zM154.9 126.1l-16.6 59.2h-5l16.5-59.2h5.1zM192.3 154.9l-29.2 20.8v-9.2l21.4-14.1v-.3l-21.4-15.7v-9.2l29.2 22.5v5.2z"
                 />
             </g>
@@ -83,10 +80,7 @@ function SvgLineWithArrow() {
         >
             <defs>
                 <marker
-                    className={classNames(
-                        styles.svgFillBlue,
-                        styles.svgStrokeBlue
-                    )}
+                    className={clsx(styles.svgFillBlue, styles.svgStrokeBlue)}
                     id="arrow"
                     viewBox="0 0 10 10"
                     refX="5"
@@ -99,7 +93,7 @@ function SvgLineWithArrow() {
                 </marker>
             </defs>
             <line
-                className={classNames(styles.arrowLine, styles.svgStrokeBlue)}
+                className={clsx(styles.arrowLine, styles.svgStrokeBlue)}
                 strokeDashoffset="-2.5"
                 strokeDasharray="10,5"
                 x1="10"

--- a/src/components/ProductCard/index.jsx
+++ b/src/components/ProductCard/index.jsx
@@ -1,14 +1,14 @@
 import useBaseUrl from "@docusaurus/useBaseUrl";
-import classnames from "classnames";
+import clsx from "clsx";
 import React from "react";
 import styles from "./index.module.css";
 import Link from "@docusaurus/Link";
 
 export default function ProductCard({ imageUrl, title, description, link }) {
     return (
-        <Link className={classnames(styles.product)} to={link}>
-            <div className={classnames("card col", styles.productCard)}>
-                <div className={classnames("card__image", styles.productImage)}>
+        <Link className={styles.product} to={link}>
+            <div className={clsx("card col", styles.productCard)}>
+                <div className={clsx("card__image", styles.productImage)}>
                     <img src={useBaseUrl(imageUrl)} alt={title} title={title} />
                 </div>
                 <div className="card__body">

--- a/src/components/ProductContainer/index.jsx
+++ b/src/components/ProductContainer/index.jsx
@@ -1,11 +1,11 @@
-import classnames from "classnames";
+import clsx from "clsx";
 import React from "react";
 import styles from "./index.module.css";
 
 export default function ProductContainer({ children }) {
     return (
         <section className={styles.productsContainer}>
-            <div className={classnames(styles.products, "row")}>{children}</div>
+            <div className={clsx(styles.products, "row")}>{children}</div>
         </section>
     );
 }

--- a/src/components/UseCaseCard/index.jsx
+++ b/src/components/UseCaseCard/index.jsx
@@ -1,11 +1,11 @@
 import Link from "@docusaurus/Link";
 import React from "react";
-import classnames from "classnames";
+import clsx from "clsx";
 import styles from "./index.module.css";
 
 export default function UseCaseCard({ title, description, link }) {
     return (
-        <div className={classnames("card-demo", styles.root)}>
+        <div className={clsx("card-demo", styles.root)}>
             <div className="card">
                 <div className="card__header">
                     <h3>{title}</h3>

--- a/src/components/UseCaseContainer/index.jsx
+++ b/src/components/UseCaseContainer/index.jsx
@@ -1,7 +1,6 @@
 import React from "react";
-import classnames from "classnames";
 import styles from "./index.module.css";
 
 export default function UseCaseContainer({ children }) {
-    return <div className={classnames(styles.root)}>{children}</div>;
+    return <div className={styles.root}>{children}</div>;
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import classNames from "classnames";
+import clsx from "clsx";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import Layout from "@theme/Layout";
 import styles from "./index.module.css";
@@ -34,7 +34,7 @@ function Home() {
     return (
         <Layout description="Developer documentation and code samples for Geocortex Products.">
             <header
-                className={classNames("hero hero--dark", styles.heroBanner)}
+                className={clsx("hero hero--dark", styles.heroBanner)}
                 // TODO: Find out correct approach to use this in CSS file,
                 // as it wasn't taking baseUrl into account.
                 style={{


### PR DESCRIPTION
Updates to the [latest docusaurus](https://github.com/facebook/docusaurus/releases/tag/v2.0.0-alpha.58).

We also swapped `classnames` for `clsx` to avoid duplication in the bundles as [docusaurus has switched](https://github.com/facebook/docusaurus/pull/2895)