### PR TITLE
Updated sample code to reflect recent namespace changes [5.8]

### DIFF
--- a/docs/workflow/sdk-server-overview.mdx
+++ b/docs/workflow/sdk-server-overview.mdx
@@ -96,7 +96,7 @@ You can debug custom Geocortex Workflow Server activities by attaching to the Ge
 To automate the deployment to Geocortex Workflow Server, we have to add a post build step to the project that copies the build output.
 
 1. Locate the `Custom Assemblies` folder in the Geocortex Workflow Server installation. The default location is `C:\Program Files\Latitude Geographics\Geocortex Workflow\CustomAssemblies`
-2. Create a file `excluded_files.txt`at the root of the project that excludes the appropriate build output files as described in the [deployment section](#deploying-geocortex-workflow-server-activities).
+2. Create a file `excluded_files.txt` at the root of the project that excludes the appropriate build output files as described in the [deployment section](#deploying-geocortex-workflow-server-activities).
 
 ```
 Geocortex.Workflow.Runtime.dll

--- a/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
+++ b/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
@@ -36,7 +36,7 @@ Implementing a custom form element in Geocortex Mobile consists of three steps:
 2. Add a new skeleton form element that implements `FormComponent`.
 
 ```cs title="App1/App1/workflow/LoadingIndicator.cs"
-using Geocortex.Workflow.Forms.Components;
+using Geocortex.Workflow.Forms.Xamarin.Components;
 using Xamarin.Forms;
 
 namespace App1.Workflow
@@ -168,7 +168,7 @@ Next we can add the loading indicator to the form element.
 
 ```cs title="App1/App1/workflow/LoadingIndicator.cs"
 using VertiGIS.Mobile.Infrastructure.UI;
-using Geocortex.Workflow.Forms.Components;
+using Geocortex.Workflow.Forms.Xamarin.Components;
 
 namespace App1.Workflow
 {

--- a/docs/workflow/tutorial-mobile-show-map-callout.mdx
+++ b/docs/workflow/tutorial-mobile-show-map-callout.mdx
@@ -36,7 +36,7 @@ First, the basic activity needs to be setup and registered. Below is an example 
 ```cs title="App1/App1/workflow/PlaceCalloutAtCenter.cs"
 using App1.Workflow;
 using VertiGIS.Mobile.Composition;
-using Geocortex.Workflow.GIS;
+using Geocortex.Workflow.GIS.ArcGISRuntime;
 using Geocortex.Workflow.Runtime;
 using System;
 using System.Collections.Generic;
@@ -130,7 +130,7 @@ To inject the MapProviderBase, add a new [Autofac factory](https://autofaccn.rea
 ```cs title="App1/App1/workflow/PlaceCalloutAtCenter.cs"
 using App1.Workflow;
 using VertiGIS.Mobile.Composition;
-using Geocortex.Workflow.GIS;
+using Geocortex.Workflow.GIS.ArcGISRuntime;
 using Geocortex.Workflow.Runtime;
 using System;
 using System.Collections.Generic;
@@ -167,7 +167,7 @@ using App1.Workflow;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Xamarin.Forms;
 using VertiGIS.Mobile.Composition;
-using Geocortex.Workflow.GIS;
+using Geocortex.Workflow.GIS.ArcGISRuntime;
 using Geocortex.Workflow.Runtime;
 using System;
 using System.Collections.Generic;
@@ -219,7 +219,7 @@ using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Xamarin.Forms;
-using Geocortex.Workflow.GIS;
+using Geocortex.Workflow.GIS.ArcGISRuntime;
 using Geocortex.Workflow.Runtime;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
The following changes were made:

* docs\workflow\tutorial-mobile-activity-indicator-form-element.mdx
    * Changed `Geocortex.Workflow.Forms.Components` to `Geocortex.Workflow.Forms.Xamarin.Components`
* docs\workflow\tutorial-mobile-show-map-callout.mdx
    * Changed `Geocortex.Workflow.GIS` to `Geocortex.Workflow.GIS.ArcGISRuntime`

The following examples were also reviewed, but did not need to be changed:

* docs\workflow\sdk-mobile-activity-reference.mdx
* docs\workflow\sdk-mobile-create-activity.mdx
* docs\workflow\sdk-mobile-form-reference.mdx
* docs\workflow\sdk-net-register-activities.mdx
* docs\workflow\sdk-server-create-activity.mdx
* docs\workflow\sdk-server-overview.mdx
* docs\workflow\tutorial-mobile-calculate-logarithm-activity.mdx
* docs\workflow\tutorial-server-calculate-logarithm-activity.mdx

AB#41021