### PR TITLE
Remove the not helpful `unknown` properties from the schema

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -47,6 +47,7 @@
         "linq",
         "mapview",
         "mkcert",
+        "modelproperties",
         "mvvm",
         "nameof",
         "netcore",

--- a/src/components/ViewerMessaging/MessagingArgument.tsx
+++ b/src/components/ViewerMessaging/MessagingArgument.tsx
@@ -179,7 +179,12 @@ export default function MessagingArgument(props: MessagingArgumentProps) {
                 return null;
             }
             if (definition.properties) {
-                return listProperties(definition, schema);
+                return (
+                    <>
+                        <code>object</code>
+                        {listProperties(definition, schema)}
+                    </>
+                );
             }
             if (
                 definition.additionalProperties &&

--- a/src/components/ViewerMessaging/MessagingDefinition.tsx
+++ b/src/components/ViewerMessaging/MessagingDefinition.tsx
@@ -1,12 +1,12 @@
 import Heading from "@theme/Heading";
 import React from "react";
+import { getDescription, listProperties } from "./MessagingArgument";
 import { MessageSchema } from "./schema";
 import {
     trimDefinitionsName,
     getArgumentDefinitionLinkId,
     getReferencedDefinition,
 } from "./utils";
-import MessagingArgument from "./MessagingArgument";
 
 const H3 = Heading("h3");
 
@@ -37,47 +37,13 @@ export default function MessagingDefinition(props: MessagingDefinitionProps) {
     return (
         <div className="margin-bottom--lg">
             <H3 id={id}>{trimmedName}</H3>
-            {definition.description && (
-                <div className="margin-bottom--md">
-                    {definition.description}
-                </div>
-            )}
+            {getDescription(definition, schema, "margin-bottom--md")}
             <div>Properties</div>
             {(!definition.properties ||
                 Object.keys(definition.properties).length === 0) && (
                 <em>This object doesn't currently contain any properties.</em>
             )}
-            {definition.properties && (
-                <div className="margin-left--sm">
-                    {Object.entries(definition.properties).map(
-                        ([propName, propDef]) => (
-                            <div key={propName} className="margin-bottom--md">
-                                <div className="margin-bottom--sm">
-                                    <code>{propName}</code>
-                                    {definition.required?.includes(
-                                        propName
-                                    ) && (
-                                        <span className="badge badge--secondary">
-                                            Required
-                                        </span>
-                                    )}
-                                </div>
-                                <div className="margin-left--sm">
-                                    <MessagingArgument
-                                        definition={propDef}
-                                        schema={schema}
-                                    />
-                                    {propDef.description && (
-                                        <div className="margin-top--sm">
-                                            {propDef.description}
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-                        )
-                    )}
-                </div>
-            )}
+            {definition.properties && listProperties(definition, schema)}
         </div>
     );
 }

--- a/src/components/ViewerMessaging/MessagingDefinitionsSummary.tsx
+++ b/src/components/ViewerMessaging/MessagingDefinitionsSummary.tsx
@@ -31,16 +31,19 @@ export default function MessagingDefinitionsSummary(
                 // properties should all come after TODO: Better sort so
                 // components are in one section and services are in another
                 .sort((a, b) => {
-                    if (
-                        a.toLocaleLowerCase().includes("modelproperties") &&
-                        b.toLocaleLowerCase().includes("modelproperties")
-                    ) {
+                    const aHasModelProps = a
+                        .toLocaleLowerCase()
+                        .includes("modelproperties");
+                    const bHasModelProps = b
+                        .toLocaleLowerCase()
+                        .includes("modelproperties");
+                    if (aHasModelProps && bHasModelProps) {
                         return a.localeCompare(b);
                     }
-                    if (a.toLocaleLowerCase().includes("modelproperties")) {
+                    if (aHasModelProps) {
                         return -1;
                     }
-                    if (b.toLocaleLowerCase().includes("modelproperties")) {
+                    if (bHasModelProps) {
                         return 1;
                     }
                     return a.localeCompare(b);

--- a/src/components/ViewerMessaging/MessagingDefinitionsSummary.tsx
+++ b/src/components/ViewerMessaging/MessagingDefinitionsSummary.tsx
@@ -27,7 +27,24 @@ export default function MessagingDefinitionsSummary(
     return (
         <div>
             {Object.keys(filteredDefinitions)
-                .sort((a, b) => a.localeCompare(b))
+                // Rudimentary sort of components / services first and then the
+                // properties should all come after TODO: Better sort so
+                // components are in one section and services are in another
+                .sort((a, b) => {
+                    if (
+                        a.toLocaleLowerCase().includes("modelproperties") &&
+                        b.toLocaleLowerCase().includes("modelproperties")
+                    ) {
+                        return a.localeCompare(b);
+                    }
+                    if (a.toLocaleLowerCase().includes("modelproperties")) {
+                        return -1;
+                    }
+                    if (b.toLocaleLowerCase().includes("modelproperties")) {
+                        return 1;
+                    }
+                    return a.localeCompare(b);
+                })
                 .map((name) => (
                     <MessagingDefinition
                         key={name}

--- a/src/components/ViewerMessaging/MessagingTypeSummary.tsx
+++ b/src/components/ViewerMessaging/MessagingTypeSummary.tsx
@@ -1,6 +1,6 @@
 import Heading from "@theme/Heading";
 import React from "react";
-import MessagingArgument from "./MessagingArgument";
+import MessagingArgument, { getDescription } from "./MessagingArgument";
 import { MessageSchema, Definition } from "./schema";
 import { getActionOrEventDefinitionLinkId, trimDefinitionsName } from "./utils";
 
@@ -59,11 +59,7 @@ export default function MessagingTypeSummary(props: MessagingTypeSummaryProps) {
                 return (
                     <div key={key} className="margin-bottom--lg">
                         <H3 id={linkId}>{key}</H3>
-                        {item.description && (
-                            <div className="margin-bottom--md">
-                                {item.description}
-                            </div>
-                        )}
+                        {getDescription(item, schema, "margin-bottom--md")}
                         <div className="margin-bottom--md">
                             <div>{`Argument ${
                                 typeIsOptional(inputItem) === true

--- a/src/components/ViewerMessaging/utils.ts
+++ b/src/components/ViewerMessaging/utils.ts
@@ -20,8 +20,14 @@ export function getReferencedDefinition(
     schema: MessageSchema
 ): Definition | undefined {
     const trimmedName = trimDefinitionsName(name);
-    // Explicitly ignore esri.rest-api definitions for now
-    if (trimmedName.startsWith("esri.rest-api")) {
+    // Explicitly ignore esri.rest-api definitions for now. Also ignore
+    // SingleCommand and SingleOperation as they result in a large list of
+    // `unknown` properties.
+    if (
+        trimmedName.startsWith("esri.rest-api") ||
+        trimmedName.startsWith("viewer-spec.SingleCommand") ||
+        trimmedName.startsWith("viewer-spec.SingleOperation")
+    ) {
         return;
     }
     return schema.definitions[trimmedName];


### PR DESCRIPTION
Remove some of the the unhelpful `unknown` properties from the schema (specifically Web/Mobile -> API -> Commands and Operations).
Change some `See @link someProperty` to the actual description from the property (specifically Web/Mobile -> API -> Commands and Operations).
Organize Components / Services to come before items referenced by them

